### PR TITLE
Add strict type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,8 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "h5py>=3.12.1",
+    "numpy>=2.1.2",
+    "packaging>=24.1",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ dev-dependencies = [
 
 [tool.uv.sources]
 scipy-stubs = { git = "https://github.com/jorenham/scipy-stubs.git" }
-h5py-stubs = { path = "../../src/h5py-stubs" }
+h5py-stubs = { git = "https://github.com/pavyamsiri/h5py-stubs.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "novie-data"
-version = "0.1.0"
+version = "0.2.0"
 description = "Data type definitions for `novie` files."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -45,10 +45,7 @@ ignore = [
 ]
 
 [tool.uv]
-dev-dependencies = [
- "h5py-stubs",
- "scipy-stubs",
-]
+dev-dependencies = ["h5py-stubs", "scipy-stubs"]
 
 [tool.uv.sources]
 scipy-stubs = { git = "https://github.com/jorenham/scipy-stubs.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,7 @@ version = "0.1.0"
 description = "Data type definitions for `novie` files."
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = [
-    "h5py>=3.12.1",
-    "numpy>=2.1.2",
-    "packaging>=24.1",
-]
+dependencies = ["h5py>=3.12.1", "numpy>=2.1.2", "packaging>=24.1"]
 
 [build-system]
 requires = ["hatchling"]
@@ -34,4 +30,26 @@ line-length = 130
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["ANN101", "ANN102", "COM812", "D203", "D213", "ISC001", "PLR0913", "PLR0915", "PLR2004", "S101", "TD003"]
+ignore = [
+    "ANN101",
+    "ANN102",
+    "COM812",
+    "D203",
+    "D213",
+    "ISC001",
+    "PLR0913",
+    "PLR0915",
+    "PLR2004",
+    "S101",
+    "TD003",
+]
+
+[tool.uv]
+dev-dependencies = [
+ "h5py-stubs",
+ "scipy-stubs",
+]
+
+[tool.uv.sources]
+scipy-stubs = { git = "https://github.com/jorenham/scipy-stubs.git" }
+h5py-stubs = { path = "../../src/h5py-stubs" }

--- a/src/novie_data/__init__.py
+++ b/src/novie_data/__init__.py
@@ -34,3 +34,5 @@ __all__ = [
     "PerturberData",
     "RidgeData",
 ]
+
+__version__: str = "0.2.0"

--- a/src/novie_data/_type_utils.py
+++ b/src/novie_data/_type_utils.py
@@ -1,0 +1,31 @@
+"""Useful types."""
+
+from typing import TypeVar
+
+import numpy as np
+
+_ST = TypeVar("_ST", bound=np.generic)
+
+AnyArray = np.ndarray[tuple[int, ...], np.dtype[np.generic]]
+AnyArrayWithDType = np.ndarray[tuple[int, ...], np.dtype[_ST]]
+
+
+def require_dtype(arr: AnyArray, dtype: type[_ST]) -> AnyArrayWithDType[_ST]:
+    """Convert the given array to the given dtype.
+
+    This is mostly used to help with static type checking.
+
+    Parameters
+    ----------
+    arr : NDArray
+        The array to convert.
+    dtype : T
+        The data type to convert to.
+
+    Returns
+    -------
+    converted_arr : NDArray[dtype[T]]
+        The converted array.
+
+    """
+    return arr.astype(dtype)

--- a/src/novie_data/arm_coverage_data.py
+++ b/src/novie_data/arm_coverage_data.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING, ClassVar, Self
 
 import numpy as np
 from h5py import File as Hdf5File
-from numpy import float32
+from numpy import float32, uint32
 from packaging.version import Version
 
-from .serde.accessors import get_string_sequence_from_hdf5, read_dataset_from_hdf5
+from .serde.accessors import get_string_sequence_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 from .solar_circle_data import SolarCircleData
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from numpy import uint32
     from numpy.typing import NDArray
 
 
@@ -111,12 +110,11 @@ class SpiralArmCoverageData:
             verify_file_type_from_hdf5(in_file, cls.DATA_FILE_TYPE)
             verify_file_version_from_hdf5(in_file, cls.VERSION)
 
-            num_covered_arm_pixels: NDArray[uint32]
-            num_covered_arm_pixels = read_dataset_from_hdf5(in_file, "num_covered_arm_pixels")
-            num_total_arm_pixels: NDArray[uint32]
-            num_total_arm_pixels = read_dataset_from_hdf5(in_file, "num_total_arm_pixels")
-            covered_arm_normalised_densities: NDArray[float32]
-            covered_arm_normalised_densities = read_dataset_from_hdf5(in_file, "covered_arm_normalised_densities")
+            num_covered_arm_pixels = read_dataset_from_hdf5_with_dtype(in_file, "num_covered_arm_pixels", dtype=uint32)
+            num_total_arm_pixels = read_dataset_from_hdf5_with_dtype(in_file, "num_total_arm_pixels", dtype=uint32)
+            covered_arm_normalised_densities = read_dataset_from_hdf5_with_dtype(
+                in_file, "covered_arm_normalised_densities", dtype=float32
+            )
             arm_names: Sequence[str] = get_string_sequence_from_hdf5(in_file, "arm_names")
             snapshot_data = SnapshotData.load_from(in_file)
             solar_circle_data = SolarCircleData.load_from(in_file)

--- a/src/novie_data/arm_data.py
+++ b/src/novie_data/arm_data.py
@@ -7,9 +7,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar, Self
 
 from h5py import File as Hdf5File
+from numpy import float32
 from packaging.version import Version
 
-from .serde.accessors import get_int_attr_from_hdf5, get_string_sequence_from_hdf5, read_dataset_from_hdf5
+from .serde.accessors import get_int_attr_from_hdf5, get_string_sequence_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 
@@ -17,7 +18,6 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path
 
-    from numpy import float32
     from numpy.typing import NDArray
 
 
@@ -88,12 +88,9 @@ class SpiralArmErrorData:
 
         """
         names: Sequence[str] = get_string_sequence_from_hdf5(in_file, "arm_names")
-        cluster_errors: NDArray[float32]
-        cluster_errors = read_dataset_from_hdf5(in_file, "arm_cluster_errors")
-        fit_errors: NDArray[float32]
-        fit_errors = read_dataset_from_hdf5(in_file, "arm_fit_errors")
-        original_fit_errors: NDArray[float32]
-        original_fit_errors = read_dataset_from_hdf5(in_file, "arm_original_fit_errors")
+        cluster_errors = read_dataset_from_hdf5_with_dtype(in_file, "arm_cluster_errors", dtype=float32)
+        fit_errors = read_dataset_from_hdf5_with_dtype(in_file, "arm_fit_errors", dtype=float32)
+        original_fit_errors = read_dataset_from_hdf5_with_dtype(in_file, "arm_original_fit_errors", dtype=float32)
         num_fit_points: int = get_int_attr_from_hdf5(in_file, "num_fit_points")
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, in_file.filename)
         return cls(

--- a/src/novie_data/cluster_data.py
+++ b/src/novie_data/cluster_data.py
@@ -11,7 +11,7 @@ from h5py import File as Hdf5File
 from numpy import float32, int8, int16
 from packaging.version import Version
 
-from .serde.accessors import get_float_attr_from_hdf5, read_dataset_from_hdf5
+from .serde.accessors import get_float_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 
@@ -71,10 +71,8 @@ class GlobalSpiralData:
             The HDF5 file to read from.
 
         """
-        overall_pitch_angles: NDArray[float32]
-        overall_pitch_angles = read_dataset_from_hdf5(in_file, "overall_pitch_angles")
-        winding_directions: NDArray[int8]
-        winding_directions = read_dataset_from_hdf5(in_file, "winding_directions")
+        overall_pitch_angles = read_dataset_from_hdf5_with_dtype(in_file, "overall_pitch_angles", dtype=float32)
+        winding_directions = read_dataset_from_hdf5_with_dtype(in_file, "winding_directions", dtype=int8)
 
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, in_file.filename)
         return cls(overall_pitch_angles=overall_pitch_angles, winding_directions=winding_directions)
@@ -180,20 +178,13 @@ class ClusterData:
             The HDF5 file to read from.
 
         """
-        arc_bounds: NDArray[float32]
-        arc_bounds = read_dataset_from_hdf5(in_file, "arc_bounds")
-        offset: NDArray[float32]
-        offset = read_dataset_from_hdf5(in_file, "offset")
-        growth_factor: NDArray[float32]
-        growth_factor = read_dataset_from_hdf5(in_file, "growth_factor")
-        initial_radius: NDArray[float32]
-        initial_radius = read_dataset_from_hdf5(in_file, "initial_radius")
-        cluster_fit_errors: NDArray[float32]
-        cluster_fit_errors = read_dataset_from_hdf5(in_file, "cluster_fit_errors")
-        is_two_revolution: NDArray[np.bool_]
-        is_two_revolution = read_dataset_from_hdf5(in_file, "is_two_revolution")
-        num_clusters: NDArray[int16]
-        num_clusters = read_dataset_from_hdf5(in_file, "num_clusters")
+        arc_bounds = read_dataset_from_hdf5_with_dtype(in_file, "arc_bounds", dtype=float32)
+        offset = read_dataset_from_hdf5_with_dtype(in_file, "offset", dtype=float32)
+        growth_factor = read_dataset_from_hdf5_with_dtype(in_file, "growth_factor", dtype=float32)
+        initial_radius = read_dataset_from_hdf5_with_dtype(in_file, "initial_radius", dtype=float32)
+        cluster_fit_errors = read_dataset_from_hdf5_with_dtype(in_file, "cluster_fit_errors", dtype=float32)
+        is_two_revolution = read_dataset_from_hdf5_with_dtype(in_file, "is_two_revolution", dtype=np.bool_)
+        num_clusters = read_dataset_from_hdf5_with_dtype(in_file, "num_clusters", dtype=int16)
 
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, in_file.filename)
         return cls(
@@ -282,8 +273,7 @@ class SpiralClusterData:
             verify_file_version_from_hdf5(file, cls.VERSION)
 
             # Arrays
-            cluster_masks: NDArray[int16]
-            cluster_masks = read_dataset_from_hdf5(file, "cluster_masks")
+            cluster_masks = read_dataset_from_hdf5_with_dtype(file, "cluster_masks", dtype=int16)
             pixel_to_distance: float = get_float_attr_from_hdf5(file, "pixel_to_distance")
 
             snapshot_data = SnapshotData.load_from(file)
@@ -476,7 +466,7 @@ class ClusterFrame:
             [current_frame.initial_radius for current_frame in frames], axis=-1, dtype=float32
         )
         is_two_revolution: NDArray[np.bool_] = np.stack(
-            [current_frame.is_two_revolution for current_frame in frames], axis=-1, dtype=float32
+            [current_frame.is_two_revolution for current_frame in frames], axis=-1, dtype=np.bool_
         )
         errors: NDArray[float32] = np.stack([current_frame.errors for current_frame in frames], axis=-1, dtype=float32)
         num_clusters: NDArray[int16] = np.stack([current_frame.num_clusters for current_frame in frames], axis=-1, dtype=int16)

--- a/src/novie_data/corrugation_data.py
+++ b/src/novie_data/corrugation_data.py
@@ -11,7 +11,7 @@ from h5py import File as Hdf5File
 from numpy import float32
 from packaging.version import Version
 
-from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5
+from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 from .solar_circle_data import SolarCircleData
@@ -338,15 +338,11 @@ class CorrugationData:
             verify_file_version_from_hdf5(file, cls.VERSION)
 
             # Projections
-            projection_rz: NDArray[float32]
-            projection_rz = read_dataset_from_hdf5(file, "projection_rz")
+            projection_rz = read_dataset_from_hdf5_with_dtype(file, "projection_rz", dtype=float32)
             # Mean height
-            radii: NDArray[float32]
-            radii = read_dataset_from_hdf5(file, "radii")
-            mean_height: NDArray[float32]
-            mean_height = read_dataset_from_hdf5(file, "mean_height")
-            mean_height_error: NDArray[float32]
-            mean_height_error = read_dataset_from_hdf5(file, "mean_height_error")
+            radii = read_dataset_from_hdf5_with_dtype(file, "radii", dtype=float32)
+            mean_height = read_dataset_from_hdf5_with_dtype(file, "mean_height", dtype=float32)
+            mean_height_error = read_dataset_from_hdf5_with_dtype(file, "mean_height_error", dtype=float32)
             snapshot_data = SnapshotData.load_from(file)
             radial_bins = RadialBinningData.load_from(file)
             height_bins = HeightBinningData.load_from(file)

--- a/src/novie_data/corrugation_residuals_data.py
+++ b/src/novie_data/corrugation_residuals_data.py
@@ -11,7 +11,7 @@ from numpy import float32
 from numpy.typing import NDArray
 from packaging.version import Version
 
-from .serde.accessors import read_dataset_from_hdf5
+from .serde.accessors import read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 
@@ -99,16 +99,11 @@ class CorrugationResidualsData:
             verify_file_version_from_hdf5(file, cls.VERSION)
 
             # Arrays
-            residuals: NDArray[float32]
-            residuals = read_dataset_from_hdf5(file, "residuals")
-            sum_of_square_residuals: NDArray[float32]
-            sum_of_square_residuals = read_dataset_from_hdf5(file, "sum_of_square_residuals")
-            relative_errors: NDArray[float32]
-            relative_errors = read_dataset_from_hdf5(file, "relative_errors")
-            mean_absolute_relative_error: NDArray[float32]
-            mean_absolute_relative_error = read_dataset_from_hdf5(file, "mean_absolute_relative_error")
-            radii: NDArray[float32]
-            radii = read_dataset_from_hdf5(file, "radii")
+            residuals = read_dataset_from_hdf5_with_dtype(file, "residuals", dtype=float32)
+            sum_of_square_residuals = read_dataset_from_hdf5_with_dtype(file, "sum_of_square_residuals", dtype=float32)
+            relative_errors = read_dataset_from_hdf5_with_dtype(file, "relative_errors", dtype=float32)
+            mean_absolute_relative_error = read_dataset_from_hdf5_with_dtype(file, "mean_absolute_relative_error", dtype=float32)
+            radii = read_dataset_from_hdf5_with_dtype(file, "radii", dtype=float32)
 
             snapshot_data = SnapshotData.load_from(file)
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, path.absolute())

--- a/src/novie_data/perturber_data.py
+++ b/src/novie_data/perturber_data.py
@@ -7,16 +7,16 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar, Self
 
 from h5py import File as Hdf5File
+from numpy import float32
 from packaging.version import Version
 
-from .serde.accessors import read_dataset_from_hdf5
+from .serde.accessors import read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from numpy import float32
     from numpy.typing import NDArray
 
 
@@ -80,12 +80,9 @@ class PerturberData:
             verify_file_version_from_hdf5(file, cls.VERSION)
 
             # Projections
-            position: NDArray[float32]
-            position = read_dataset_from_hdf5(file, "position")
-            velocity: NDArray[float32]
-            velocity = read_dataset_from_hdf5(file, "velocity")
-            mass: NDArray[float32]
-            mass = read_dataset_from_hdf5(file, "mass")
+            position = read_dataset_from_hdf5_with_dtype(file, "position", dtype=float32)
+            velocity = read_dataset_from_hdf5_with_dtype(file, "velocity", dtype=float32)
+            mass = read_dataset_from_hdf5_with_dtype(file, "mass", dtype=float32)
             snapshot_data = SnapshotData.load_from(file)
 
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, path.absolute())

--- a/src/novie_data/ridge_data.py
+++ b/src/novie_data/ridge_data.py
@@ -12,7 +12,7 @@ from numpy import float32
 from numpy.typing import NDArray
 from packaging.version import Version
 
-from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5
+from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 
@@ -90,10 +90,8 @@ class RidgeData:
             max_velocity: float = get_float_attr_from_hdf5(file, "max_velocity")
 
             # Arrays
-            mass_density: NDArray[float32]
-            mass_density = read_dataset_from_hdf5(file, "mass_density")
-            number_density: NDArray[float32]
-            number_density = read_dataset_from_hdf5(file, "number_density")
+            mass_density = read_dataset_from_hdf5_with_dtype(file, "mass_density", dtype=float32)
+            number_density = read_dataset_from_hdf5_with_dtype(file, "number_density", dtype=float32)
 
             snapshot_data = SnapshotData.load_from(file)
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, path.absolute())

--- a/src/novie_data/snail_data.py
+++ b/src/novie_data/snail_data.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 from scipy.ndimage import gaussian_filter
 
 from .neighbourhood_data import SphericalNeighbourhoodData
-from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5
+from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 from .solar_circle_data import SolarCircleData
@@ -187,12 +187,9 @@ class SnailData:
             max_velocity: float = get_float_attr_from_hdf5(file, "max_velocity")
 
             # Arrays
-            surface_density: NDArray[float32]
-            surface_density = read_dataset_from_hdf5(file, "surface_density")
-            azimuthal_velocity: NDArray[float32]
-            azimuthal_velocity = read_dataset_from_hdf5(file, "azimuthal_velocity")
-            radial_velocity: NDArray[float32]
-            radial_velocity = read_dataset_from_hdf5(file, "radial_velocity")
+            surface_density = read_dataset_from_hdf5_with_dtype(file, "surface_density", dtype=float32)
+            azimuthal_velocity = read_dataset_from_hdf5_with_dtype(file, "azimuthal_velocity", dtype=float32)
+            radial_velocity = read_dataset_from_hdf5_with_dtype(file, "radial_velocity", dtype=float32)
 
             snapshot_data = SnapshotData.load_from(file)
             solar_circle_data = SolarCircleData.load_from(file)

--- a/src/novie_data/snapshot_data.py
+++ b/src/novie_data/snapshot_data.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Self
+from pathlib import Path
+from typing import TYPE_CHECKING, Self, cast
 
 import numpy as np
 
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
 log: logging.Logger = logging.getLogger(__name__)
 
 
-@dataclass
 class SnapshotData:
     """The data that is general to a collection of snapshots.
 
@@ -34,12 +33,18 @@ class SnapshotData:
 
     """
 
-    names: Sequence[str]
-    times: NDArray[float32]
+    def __init__(self, names: Sequence[str], times: NDArray[float32]) -> None:
+        """Initialize the snapshot data.
 
-    def __post_init__(self) -> None:
-        """Perform post-initialisation verification."""
-        times_dimension = len(self.times.shape)
+        Parameters
+        ----------
+        names : Sequence[str]
+            The names of each snapshot.
+        times : NDArray[float32]
+            The time associated with each snapshot in Myr.
+
+        """
+        times_dimension = len(cast(tuple[int], times.shape))
         if times_dimension != 1:
             msg = f"Expected `times` to be a 1D array but it is {times_dimension}D instead!"
             raise ValueError(msg)
@@ -50,6 +55,8 @@ class SnapshotData:
             msg = f"The number of times {num_times} is not equal to the number of snapshot names {num_names}!"
             raise ValueError(msg)
 
+        self.names: Sequence[str] = names
+        self.times: NDArray[float32] = times
         self.num_frames: int = num_times
 
     def dump_into(self, out_file: Hdf5File) -> None:
@@ -62,9 +69,13 @@ class SnapshotData:
 
         """
         # General
-        out_file.create_dataset("snapshot_names", data=self.names)
-        out_file.create_dataset("times", data=self.times)
-        log.info("Successfully dumped [cyan]%s[/cyan] to [magenta]%s[/magenta]", type(self).__name__, out_file.filename)
+        _ = out_file.create_dataset("snapshot_names", data=self.names)
+        _ = out_file.create_dataset("times", data=self.times)
+        log.info(
+            "Successfully dumped [cyan]%s[/cyan] to [magenta]%s[/magenta]",
+            type(self).__name__,
+            Path(out_file.filename).absolute(),
+        )
 
     @classmethod
     def load_from(cls, in_file: Hdf5File) -> Self:

--- a/src/novie_data/snapshot_data.py
+++ b/src/novie_data/snapshot_data.py
@@ -7,14 +7,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Self, cast
 
 import numpy as np
+from numpy import float32
 
-from .serde.accessors import get_and_read_dataset_from_hdf5, get_string_sequence_from_hdf5
+from .serde.accessors import get_string_sequence_from_hdf5, read_dataset_from_hdf5_with_dtype
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from h5py import File as Hdf5File
-    from numpy import float32
     from numpy.typing import NDArray
 
 
@@ -88,7 +88,7 @@ class SnapshotData:
 
         """
         snapshot_names: Sequence[str] = get_string_sequence_from_hdf5(in_file, "snapshot_names")
-        times, _ = get_and_read_dataset_from_hdf5(in_file, "times")
+        times = read_dataset_from_hdf5_with_dtype(in_file, "times", dtype=float32)
 
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, in_file.filename)
         return cls(

--- a/src/novie_data/surface_density_data.py
+++ b/src/novie_data/surface_density_data.py
@@ -11,7 +11,7 @@ from h5py import File as Hdf5File
 from numpy import float32
 from packaging.version import Version
 
-from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5
+from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 
@@ -175,15 +175,11 @@ class SurfaceDensityData:
             num_bins: int = get_int_attr_from_hdf5(file, "num_bins")
 
             # Projections
-            projection_xy: NDArray[float32]
-            projection_xy = read_dataset_from_hdf5(file, "projection_xy")
-            projection_xz: NDArray[float32]
-            projection_xz = read_dataset_from_hdf5(file, "projection_xz")
-            projection_yz: NDArray[float32]
-            projection_yz = read_dataset_from_hdf5(file, "projection_yz")
+            projection_xy = read_dataset_from_hdf5_with_dtype(file, "projection_xy", dtype=float32)
+            projection_xz = read_dataset_from_hdf5_with_dtype(file, "projection_xz", dtype=float32)
+            projection_yz = read_dataset_from_hdf5_with_dtype(file, "projection_yz", dtype=float32)
 
-            flat_projection_xy: NDArray[float32]
-            flat_projection_xy = read_dataset_from_hdf5(file, "flat_projection_xy")
+            flat_projection_xy = read_dataset_from_hdf5_with_dtype(file, "flat_projection_xy", dtype=float32)
 
             disc_profile = ExponentialDiscProfileData.load_from(file)
             snapshot_data = SnapshotData.load_from(file)
@@ -260,7 +256,7 @@ class SurfaceDensityData:
         min_xy = np.nanmin(self.projection_xy[self.projection_xy > 0])
         min_xz = np.nanmin(self.projection_xz[self.projection_xz > 0])
         min_yz = np.nanmin(self.projection_yz[self.projection_yz > 0])
-        return float(min(min_xy, min_xz, min_yz))
+        return float(np.min([min_xy, min_xz, min_yz]))
 
     def get_min_flat_density(self) -> float:
         """Return the minimum (non-zero) flattened density in the xy projection.
@@ -285,7 +281,7 @@ class SurfaceDensityData:
         max_xy = np.nanmax(self.projection_xy)
         max_xz = np.nanmax(self.projection_xz)
         max_yz = np.nanmax(self.projection_yz)
-        return float(max(max_xy, max_xz, max_yz))
+        return float(np.max([max_xy, max_xz, max_yz]))
 
     def get_max_flat_density(self) -> float:
         """Return the maximum (non-zero) flattened density in the xy projection.

--- a/src/novie_data/wrinkle_data.py
+++ b/src/novie_data/wrinkle_data.py
@@ -7,10 +7,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar, Self
 
 from h5py import File as Hdf5File
+from numpy import float32
 from packaging.version import Version
 
 from .neighbourhood_data import SphericalNeighbourhoodData
-from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5
+from .serde.accessors import get_float_attr_from_hdf5, get_int_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 from .solar_circle_data import SolarCircleData
@@ -18,7 +19,6 @@ from .solar_circle_data import SolarCircleData
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from numpy import float32
     from numpy.typing import NDArray
 
 
@@ -128,12 +128,9 @@ class WrinkleData:
             max_lz: float = get_float_attr_from_hdf5(file, "max_lz")
 
             # Projections
-            angular_momentum: NDArray[float32]
-            angular_momentum = read_dataset_from_hdf5(file, "angular_momentum")
-            mean_radial_velocity: NDArray[float32]
-            mean_radial_velocity = read_dataset_from_hdf5(file, "mean_radial_velocity")
-            mean_radial_velocity_error: NDArray[float32]
-            mean_radial_velocity_error = read_dataset_from_hdf5(file, "mean_radial_velocity_error")
+            angular_momentum = read_dataset_from_hdf5_with_dtype(file, "angular_momentum", dtype=float32)
+            mean_radial_velocity = read_dataset_from_hdf5_with_dtype(file, "mean_radial_velocity", dtype=float32)
+            mean_radial_velocity_error = read_dataset_from_hdf5_with_dtype(file, "mean_radial_velocity_error", dtype=float32)
 
             solar_circle_data = SolarCircleData.load_from(file)
             neighbourhood_data = SphericalNeighbourhoodData.load_from(file)

--- a/src/novie_data/wrinkle_residuals_data.py
+++ b/src/novie_data/wrinkle_residuals_data.py
@@ -11,7 +11,7 @@ from numpy import float32
 from numpy.typing import NDArray
 from packaging.version import Version
 
-from .serde.accessors import read_dataset_from_hdf5
+from .serde.accessors import read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
 from .snapshot_data import SnapshotData
 
@@ -100,15 +100,15 @@ class WrinkleResidualsData:
 
             # Arrays
             residuals: NDArray[float32]
-            residuals = read_dataset_from_hdf5(file, "residuals")
+            residuals = read_dataset_from_hdf5_with_dtype(file, "residuals", dtype=float32)
             sum_of_square_residuals: NDArray[float32]
-            sum_of_square_residuals = read_dataset_from_hdf5(file, "sum_of_square_residuals")
+            sum_of_square_residuals = read_dataset_from_hdf5_with_dtype(file, "sum_of_square_residuals", dtype=float32)
             relative_errors: NDArray[float32]
-            relative_errors = read_dataset_from_hdf5(file, "relative_errors")
+            relative_errors = read_dataset_from_hdf5_with_dtype(file, "relative_errors", dtype=float32)
             mean_absolute_relative_error: NDArray[float32]
-            mean_absolute_relative_error = read_dataset_from_hdf5(file, "mean_absolute_relative_error")
+            mean_absolute_relative_error = read_dataset_from_hdf5_with_dtype(file, "mean_absolute_relative_error", dtype=float32)
             angular_momentum: NDArray[float32]
-            angular_momentum = read_dataset_from_hdf5(file, "radii")
+            angular_momentum = read_dataset_from_hdf5_with_dtype(file, "radii", dtype=float32)
 
             snapshot_data = SnapshotData.load_from(file)
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, path.absolute())

--- a/uv.lock
+++ b/uv.lock
@@ -25,16 +25,10 @@ wheels = [
 [[package]]
 name = "h5py-stubs"
 version = "0.1.0"
-source = { directory = "../../src/h5py-stubs" }
+source = { git = "https://github.com/pavyamsiri/h5py-stubs.git#4dc06e95d48ee3e70c91fcb215098f22f43a236a" }
 dependencies = [
     { name = "h5py" },
     { name = "optype" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "h5py", specifier = ">=3.12.1" },
-    { name = "optype", specifier = ">=0.6.1" },
 ]
 
 [[package]]
@@ -62,7 +56,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "h5py-stubs", directory = "../../src/h5py-stubs" },
+    { name = "h5py-stubs", git = "https://github.com/pavyamsiri/h5py-stubs.git" },
     { name = "scipy-stubs", git = "https://github.com/jorenham/scipy-stubs.git" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -23,6 +23,21 @@ wheels = [
 ]
 
 [[package]]
+name = "h5py-stubs"
+version = "0.1.0"
+source = { directory = "../../src/h5py-stubs" }
+dependencies = [
+    { name = "h5py" },
+    { name = "optype" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "h5py", specifier = ">=3.12.1" },
+    { name = "optype", specifier = ">=0.6.1" },
+]
+
+[[package]]
 name = "novie-data"
 version = "0.1.0"
 source = { editable = "." }
@@ -32,11 +47,23 @@ dependencies = [
     { name = "packaging" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "h5py-stubs" },
+    { name = "scipy-stubs" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "h5py", specifier = ">=3.12.1" },
     { name = "numpy", specifier = ">=2.1.2" },
     { name = "packaging", specifier = ">=24.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "h5py-stubs", directory = "../../src/h5py-stubs" },
+    { name = "scipy-stubs", git = "https://github.com/jorenham/scipy-stubs.git" },
 ]
 
 [[package]]
@@ -76,10 +103,67 @@ wheels = [
 ]
 
 [[package]]
+name = "optype"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/38/2d936e807e1559993f3b20d643c023470e31d0f9c3bea2d9d72835e88436/optype-0.6.1.tar.gz", hash = "sha256:3a410d65632a449e63a03182eb504d03f404427a99724868e7e393eb8e376207", size = 74229 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/58/39a30061163df33b5ffed0c1deeca3af3fa61f00ba2bb7f5af39a31dfb77/optype-0.6.1-py3-none-any.whl", hash = "sha256:ba45f940b7d858225c2995e273f404f1c7c8b2f1d71041b1413e5105104d2515", size = 62528 },
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002", size = 148788 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124", size = 53985 },
+]
+
+[[package]]
+name = "scipy"
+version = "1.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/62/11/4d44a1f274e002784e4dbdb81e0ea96d2de2d1045b2132d5af62cc31fd28/scipy-1.14.1.tar.gz", hash = "sha256:5a275584e726026a5699459aa72f828a610821006228e841b94275c4a7c08417", size = 58620554 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/04/2bdacc8ac6387b15db6faa40295f8bd25eccf33f1f13e68a72dc3c60a99e/scipy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:631f07b3734d34aced009aaf6fedfd0eb3498a97e581c3b1e5f14a04164a456d", size = 39128781 },
+    { url = "https://files.pythonhosted.org/packages/c8/53/35b4d41f5fd42f5781dbd0dd6c05d35ba8aa75c84ecddc7d44756cd8da2e/scipy-1.14.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:af29a935803cc707ab2ed7791c44288a682f9c8107bc00f0eccc4f92c08d6e07", size = 29939542 },
+    { url = "https://files.pythonhosted.org/packages/66/67/6ef192e0e4d77b20cc33a01e743b00bc9e68fb83b88e06e636d2619a8767/scipy-1.14.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2843f2d527d9eebec9a43e6b406fb7266f3af25a751aa91d62ff416f54170bc5", size = 23148375 },
+    { url = "https://files.pythonhosted.org/packages/f6/32/3a6dedd51d68eb7b8e7dc7947d5d841bcb699f1bf4463639554986f4d782/scipy-1.14.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:eb58ca0abd96911932f688528977858681a59d61a7ce908ffd355957f7025cfc", size = 25578573 },
+    { url = "https://files.pythonhosted.org/packages/f0/5a/efa92a58dc3a2898705f1dc9dbaf390ca7d4fba26d6ab8cfffb0c72f656f/scipy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30ac8812c1d2aab7131a79ba62933a2a76f582d5dbbc695192453dae67ad6310", size = 35319299 },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/8a26858ca517e9c64f84b4c7734b89bda8e63bec85c3d2f432d225bb1886/scipy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f9ea80f2e65bdaa0b7627fb00cbeb2daf163caa015e59b7516395fe3bd1e066", size = 40849331 },
+    { url = "https://files.pythonhosted.org/packages/a5/cd/06f72bc9187840f1c99e1a8750aad4216fc7dfdd7df46e6280add14b4822/scipy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:edaf02b82cd7639db00dbff629995ef185c8df4c3ffa71a5562a595765a06ce1", size = 42544049 },
+    { url = "https://files.pythonhosted.org/packages/aa/7d/43ab67228ef98c6b5dd42ab386eae2d7877036970a0d7e3dd3eb47a0d530/scipy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2ff38e22128e6c03ff73b6bb0f85f897d2362f8c052e3b8ad00532198fbdae3f", size = 44521212 },
+    { url = "https://files.pythonhosted.org/packages/50/ef/ac98346db016ff18a6ad7626a35808f37074d25796fd0234c2bb0ed1e054/scipy-1.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1729560c906963fc8389f6aac023739ff3983e727b1a4d87696b7bf108316a79", size = 39091068 },
+    { url = "https://files.pythonhosted.org/packages/b9/cc/70948fe9f393b911b4251e96b55bbdeaa8cca41f37c26fd1df0232933b9e/scipy-1.14.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:4079b90df244709e675cdc8b93bfd8a395d59af40b72e339c2287c91860deb8e", size = 29875417 },
+    { url = "https://files.pythonhosted.org/packages/3b/2e/35f549b7d231c1c9f9639f9ef49b815d816bf54dd050da5da1c11517a218/scipy-1.14.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e0cf28db0f24a38b2a0ca33a85a54852586e43cf6fd876365c86e0657cfe7d73", size = 23084508 },
+    { url = "https://files.pythonhosted.org/packages/3f/d6/b028e3f3e59fae61fb8c0f450db732c43dd1d836223a589a8be9f6377203/scipy-1.14.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:0c2f95de3b04e26f5f3ad5bb05e74ba7f68b837133a4492414b3afd79dfe540e", size = 25503364 },
+    { url = "https://files.pythonhosted.org/packages/a7/2f/6c142b352ac15967744d62b165537a965e95d557085db4beab2a11f7943b/scipy-1.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b99722ea48b7ea25e8e015e8341ae74624f72e5f21fc2abd45f3a93266de4c5d", size = 35292639 },
+    { url = "https://files.pythonhosted.org/packages/56/46/2449e6e51e0d7c3575f289f6acb7f828938eaab8874dbccfeb0cd2b71a27/scipy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5149e3fd2d686e42144a093b206aef01932a0059c2a33ddfa67f5f035bdfe13e", size = 40798288 },
+    { url = "https://files.pythonhosted.org/packages/32/cd/9d86f7ed7f4497c9fd3e39f8918dd93d9f647ba80d7e34e4946c0c2d1a7c/scipy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e4f5a7c49323533f9103d4dacf4e4f07078f360743dec7f7596949149efeec06", size = 42524647 },
+    { url = "https://files.pythonhosted.org/packages/f5/1b/6ee032251bf4cdb0cc50059374e86a9f076308c1512b61c4e003e241efb7/scipy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:baff393942b550823bfce952bb62270ee17504d02a1801d7fd0719534dfb9c84", size = 44469524 },
+]
+
+[[package]]
+name = "scipy-stubs"
+version = "1.4.1a3"
+source = { git = "https://github.com/jorenham/scipy-stubs.git#ce78eb063454f930ab0f5cee7bab4ac3affd40d9" }
+dependencies = [
+    { name = "optype" },
+    { name = "scipy" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -28,10 +28,16 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "h5py" },
+    { name = "numpy" },
+    { name = "packaging" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "h5py", specifier = ">=3.12.1" }]
+requires-dist = [
+    { name = "h5py", specifier = ">=3.12.1" },
+    { name = "numpy", specifier = ">=2.1.2" },
+    { name = "packaging", specifier = ">=24.1" },
+]
 
 [[package]]
 name = "numpy"
@@ -67,4 +73,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/8e/fc1fdd83a55476765329ac2913321c4aed5b082a7915095628c4ca30ea72/numpy-2.1.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13311c2db4c5f7609b462bc0f43d3c465424d25c626d95040f073e30f7570e35", size = 16021174 },
     { url = "https://files.pythonhosted.org/packages/2a/b6/a790742aa88067adb4bd6c89a946778c1417d4deaeafce3ca928f26d4c52/numpy-2.1.2-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:2abbf905a0b568706391ec6fa15161fad0fb5d8b68d73c461b3c1bab6064dd62", size = 16400117 },
     { url = "https://files.pythonhosted.org/packages/48/6f/129e3c17e3befe7fefdeaa6890f4c4df3f3cf0831aa053802c3862da67aa/numpy-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ef444c57d664d35cac4e18c298c47d7b504c66b17c2ea91312e979fcfbdfb08a", size = 14066202 },
+]
+
+[[package]]
+name = "packaging"
+version = "24.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002", size = 148788 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/aa/cc0199a5f0ad350994d660967a8efb233fe0416e4639146c089643407ce6/packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124", size = 53985 },
 ]


### PR DESCRIPTION
This mostly required work on h5py-stubs to get working types on HDF5 (de)serialisation. The scipy stubs are incomplete however that is independent of this repo.