### PR TITLE
Implement a new residuals interface to unify corrugation and wrinkle residuals data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "novie-data"
-version = "2.1.0"
+version = "3.0.0"
 description = "Data type definitions for `novie` files."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/novie_data/__init__.py
+++ b/src/novie_data/__init__.py
@@ -30,4 +30,4 @@ __all__ = [
     "NovieData",
 ]
 
-__version__: str = "2.1.0"
+__version__: str = "3.0.0"

--- a/src/novie_data/corrugation_residuals_data.py
+++ b/src/novie_data/corrugation_residuals_data.py
@@ -3,29 +3,16 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, ClassVar, Literal, Self, TypeAlias
+from typing import ClassVar
 
-import numpy as np
-from h5py import File as Hdf5File
 from packaging.version import Version
 
-from novie_data._type_utils import Array1D, Array2D, Array3D, verify_array_is_1d, verify_array_is_2d, verify_array_is_3d
-from novie_data.errors import verify_arrays_are_consistent
-
-from .serde.accessors import get_str_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
-from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-_Array1D_f32: TypeAlias = Array1D[np.float32]
-_Array2D_f32: TypeAlias = Array2D[np.float32]
-_Array3D_f32: TypeAlias = Array3D[np.float32]
+from .signal_residuals_data import SignalResidualsData
 
 log: logging.Logger = logging.getLogger(__name__)
 
 
-class CorrugationResidualsData:
+class CorrugationResidualsData(SignalResidualsData):
     """Data class to store residuals and errors from corrugation data processing.
 
     Attributes
@@ -46,175 +33,26 @@ class CorrugationResidualsData:
     DATA_FILE_TYPE: ClassVar[str] = "CorrugationResiduals"
     VERSION: ClassVar[Version] = Version("2.0.0")
 
-    def __init__(
-        self,
-        *,
-        name: str,
-        metric_name: str,
-        metric: _Array3D_f32,
-        summary: _Array2D_f32,
-        bin_values: _Array1D_f32,
-    ) -> None:
-        """Initialize the data class.
-
-        Parameters
-        ----------
-        name : str
-            The name of the data set.
-        metric_name : str
-            The name of the metric used.
-        metric : Array3D[f32]
-            The value of the metric per point, frame and location.
-        summary : Array2D[f32]
-            The summary statistic of the metric per frame and location.
-        bin_values : Array1D[f32]
-            The central bin value for each bin.
-
-        """
-        self.name: str = name
-        self.metric_name: str = metric_name
-        self.metric: _Array3D_f32 = metric
-        self.summary: _Array2D_f32 = summary
-        self.bin_values: _Array1D_f32 = bin_values
-
-        verify_arrays_are_consistent(
-            [(self.bin_values, 0), (self.metric, 0)],
-            msg="Expected the bin values and metric arrays to have the same number of rows.",
-        )
-        verify_arrays_are_consistent(
-            [
-                (self.metric, 1),
-                (self.summary, 0),
-            ],
-            msg="Expected the arrays to have the same number of frames!",
-        )
-        verify_arrays_are_consistent(
-            [
-                (self.metric, 2),
-                (self.summary, 1),
-            ],
-            msg="Expected the arrays to have the same number of neighbourhoods!",
-        )
-
-    def __eq__(self, other: object, /) -> bool:
-        """Compare for equality.
-
-        Parameters
-        ----------
-        other : object
-            The object to compare to.
+    @classmethod
+    def get_data_file_type(cls) -> str:
+        """Return the data file type string for this class.
 
         Returns
         -------
-        bool
-            `True` if the other object is equal to this object, `False` otherwise.
-
-        Notes
-        -----
-        Equality means all fields are equal.
+        file_type : str
+            The data file type.
 
         """
-        if not isinstance(other, type(self)):
-            return False
-        equality = True
-        equality &= self.name == other.name
-        equality &= self.metric_name == other.metric_name
-        equality &= np.all(self.bin_values == other.bin_values)
-        equality &= np.all(self.metric == other.metric)
-        equality &= np.all(self.summary == other.summary)
-        return bool(equality)
-
-    def get_extremal_index_over_summary(self, extremum: Literal["min", "max"]) -> tuple[int, int]:
-        """Get the frame and location indices that minimises the summary statistic.
-
-        Returns
-        -------
-        frame_index : int
-            The index of the frame that extremises the summary statistic.
-        location_index : int
-            The index of the location that extremises the summary statistic.
-
-        """
-        extremum_index = np.nanargmin(self.summary) if extremum == "min" else np.nanargmax(self.summary)
-        frame_index, location_index = np.unravel_index(extremum_index, self.summary.shape)
-        return int(frame_index), int(location_index)
+        return cls.DATA_FILE_TYPE
 
     @classmethod
-    def load(cls, path: Path) -> Self:
-        """Deserialize phase spiral data from file.
-
-        Parameters
-        ----------
-        path : Path
-            The path to the data.
+    def get_version(cls) -> Version:
+        """Return the version for this class.
 
         Returns
         -------
-        CorrugationResidualsData
-            The deserialized data.
+        version : Version
+            The file version.
 
         """
-        with Hdf5File(path, "r") as file:
-            verify_file_type_from_hdf5(file, cls.DATA_FILE_TYPE)
-            verify_file_version_from_hdf5(file, cls.VERSION)
-
-            name: str = get_str_attr_from_hdf5(file, "name")
-            metric_name: str = get_str_attr_from_hdf5(file, "metric_name")
-
-            # Arrays
-            bin_values = verify_array_is_1d(read_dataset_from_hdf5_with_dtype(file, "bin_values", dtype=np.float32))
-            metric = verify_array_is_3d(read_dataset_from_hdf5_with_dtype(file, "metric", dtype=np.float32))
-            summary = verify_array_is_2d(read_dataset_from_hdf5_with_dtype(file, "summary", dtype=np.float32))
-
-        log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, path.absolute())
-        return cls(
-            name=name,
-            metric_name=metric_name,
-            metric=metric,
-            summary=summary,
-            bin_values=bin_values,
-        )
-
-    def dump(self, path: Path) -> None:
-        """Serialize phase spiral data to disk.
-
-        Parameters
-        ----------
-        path : Path
-            The path to the data.
-
-        """
-        with Hdf5File(path, "w") as file:
-            # General
-            file.attrs["type"] = CorrugationResidualsData.DATA_FILE_TYPE
-            file.attrs["version"] = str(CorrugationResidualsData.VERSION)
-            file.attrs["name"] = self.name
-            file.attrs["metric_name"] = self.metric_name
-            file.create_dataset("metric", data=self.metric)
-            file.create_dataset("summary", data=self.summary)
-            file.create_dataset("radii", data=self.bin_values)
-        log.info(
-            "Successfully dumped [cyan]%s[/cyan] to [magenta]%s[/magenta]", CorrugationResidualsData.__name__, path.absolute()
-        )
-
-    # Convenience functions
-    @property
-    def num_frames(self) -> int:
-        """int: The number of frames."""
-        return self.metric.shape[1]
-
-    @property
-    def num_locations(self) -> int:
-        """int: The number of filters."""
-        return self.metric.shape[2]
-
-    def get_starting_angles_deg(self) -> _Array1D_f32:
-        """Return the angle of the start locations in degrees.
-
-        Returns
-        -------
-        starting_angles : Array1D[f32]
-            The angle of the start locations in degrees.
-
-        """
-        return np.linspace(0, 360, self.num_locations, endpoint=False)
+        return cls.VERSION

--- a/src/novie_data/corrugation_residuals_data.py
+++ b/src/novie_data/corrugation_residuals_data.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, ClassVar, Self, TypeAlias
+from typing import TYPE_CHECKING, ClassVar, Literal, Self, TypeAlias
 
 import numpy as np
 from h5py import File as Hdf5File
 from packaging.version import Version
 
 from novie_data._type_utils import Array1D, Array2D, Array3D, verify_array_is_1d, verify_array_is_2d, verify_array_is_3d
-from novie_data.errors import verify_arrays_are_consistent, verify_arrays_have_same_shape
+from novie_data.errors import verify_arrays_are_consistent
 
 from .serde.accessors import get_str_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
@@ -32,31 +32,28 @@ class CorrugationResidualsData:
     ----------
     name : str
         The name of the data set.
-    radii : Array1D[f32]
-        The central radius value for each radial bin in units of kpc.
-    residuals : Array3D[f32]
-        The residuals between the test mean height and the expected mean height in units of kpc.
-    relative_errors : Array3D[f32]
-        The relative residuals between the test mean height and the expected mean height.
-    sum_of_square_residuals: Array2D[f32]
-        The sum of square residuals for each frame and filter in units of kpc**2.
-    mean_absolute_relative_error : Array2D[f32]
-        The mean absolute relative error.
+    metric_name : str
+        The name of the metric used.
+    metric : Array3D[f32]
+        The value of the metric per point, frame and location.
+    summary : Array2D[f32]
+        The summary statistic of the metric per frame and location.
+    bin_values : Array1D[f32]
+        The central bin value for each bin.
 
     """
 
     DATA_FILE_TYPE: ClassVar[str] = "CorrugationResiduals"
-    VERSION: ClassVar[Version] = Version("1.0.0")
+    VERSION: ClassVar[Version] = Version("2.0.0")
 
     def __init__(
         self,
         *,
         name: str,
-        radii: _Array1D_f32,
-        residuals: _Array3D_f32,
-        relative_errors: _Array3D_f32,
-        sum_of_square_residuals: _Array2D_f32,
-        mean_absolute_relative_error: _Array2D_f32,
+        metric_name: str,
+        metric: _Array3D_f32,
+        summary: _Array2D_f32,
+        bin_values: _Array1D_f32,
     ) -> None:
         """Initialize the data class.
 
@@ -64,52 +61,37 @@ class CorrugationResidualsData:
         ----------
         name : str
             The name of the data set.
-        radii : Array1D[f32]
-            The central radius value for each radial bin in units of kpc.
-        residuals : Array3D[f32]
-            The residuals between the test mean height and the expected mean height in units of kpc.
-        relative_errors : Array3D[f32]
-            The relative residuals between the test mean height and the expected mean height.
-        sum_of_square_residuals: Array2D[f32]
-            The sum of square residuals for each frame and filter in units of kpc**2.
-        mean_absolute_relative_error : Array2D[f32]
-            The mean absolute relative error.
+        metric_name : str
+            The name of the metric used.
+        metric : Array3D[f32]
+            The value of the metric per point, frame and location.
+        summary : Array2D[f32]
+            The summary statistic of the metric per frame and location.
+        bin_values : Array1D[f32]
+            The central bin value for each bin.
 
         """
         self.name: str = name
-        self.radii: _Array1D_f32 = radii
-        self.residuals: _Array3D_f32 = residuals
-        self.relative_errors: _Array3D_f32 = relative_errors
-        self.sum_of_square_residuals: _Array2D_f32 = sum_of_square_residuals
-        self.mean_absolute_relative_error: _Array2D_f32 = mean_absolute_relative_error
+        self.metric_name: str = metric_name
+        self.metric: _Array3D_f32 = metric
+        self.summary: _Array2D_f32 = summary
+        self.bin_values: _Array1D_f32 = bin_values
 
-        verify_arrays_have_same_shape(
-            [self.residuals, self.relative_errors],
-            msg="Expected the residuals and relative errors arrays to have the same shape!",
-        )
-        verify_arrays_have_same_shape(
-            [self.sum_of_square_residuals, self.mean_absolute_relative_error],
-            msg="Expected the SSE and MARE arrays to have the same shape!",
-        )
         verify_arrays_are_consistent(
-            [(self.radii, 0), (self.residuals, 0), (self.relative_errors, 0)],
-            msg="Expected the radii, residuals and relative errors arrays to have the same number of rows.",
+            [(self.bin_values, 0), (self.metric, 0)],
+            msg="Expected the bin values and metric arrays to have the same number of rows.",
         )
         verify_arrays_are_consistent(
             [
-                (self.residuals, 1),
-                (self.relative_errors, 1),
-                (self.sum_of_square_residuals, 0),
-                (self.mean_absolute_relative_error, 0),
+                (self.metric, 1),
+                (self.summary, 0),
             ],
             msg="Expected the arrays to have the same number of frames!",
         )
         verify_arrays_are_consistent(
             [
-                (self.residuals, 2),
-                (self.relative_errors, 2),
-                (self.sum_of_square_residuals, 1),
-                (self.mean_absolute_relative_error, 1),
+                (self.metric, 2),
+                (self.summary, 1),
             ],
             msg="Expected the arrays to have the same number of neighbourhoods!",
         )
@@ -136,42 +118,26 @@ class CorrugationResidualsData:
             return False
         equality = True
         equality &= self.name == other.name
-        equality &= np.all(self.radii == other.radii)
-        equality &= np.all(self.residuals == other.residuals)
-        equality &= np.all(self.relative_errors == other.relative_errors)
-        equality &= np.all(self.sum_of_square_residuals == other.sum_of_square_residuals)
-        equality &= np.all(self.mean_absolute_relative_error == other.mean_absolute_relative_error)
+        equality &= self.metric_name == other.metric_name
+        equality &= np.all(self.bin_values == other.bin_values)
+        equality &= np.all(self.metric == other.metric)
+        equality &= np.all(self.summary == other.summary)
         return bool(equality)
 
-    def get_argmin_over_absolute(self) -> tuple[int, int]:
-        """Get the frame and filter indices that minimises the sum of square residuals.
+    def get_extremal_index_over_summary(self, extremum: Literal["min", "max"]) -> tuple[int, int]:
+        """Get the frame and location indices that minimises the summary statistic.
 
         Returns
         -------
-        min_frame : int
-            The index of the frame that minimises the sum of square residuals.
-        min_filter : int
-            The index of the filter that minimises the sum of square residuals.
+        frame_index : int
+            The index of the frame that extremises the summary statistic.
+        location_index : int
+            The index of the location that extremises the summary statistic.
 
         """
-        min_idx = np.nanargmin(self.sum_of_square_residuals)
-        min_frame, min_filter = np.unravel_index(min_idx, self.sum_of_square_residuals.shape)
-        return int(min_frame), int(min_filter)
-
-    def get_argmin_over_relative(self) -> tuple[int, int]:
-        """Get the frame and filter indices that minimises the mean absolute relative error.
-
-        Returns
-        -------
-        min_frame : int
-            The index of the frame that minimises the mean absolute relative error.
-        min_filter : int
-            The index of the filter that minimises the mean absolute relative error.
-
-        """
-        min_idx = np.nanargmin(self.mean_absolute_relative_error)
-        min_frame, min_filter = np.unravel_index(min_idx, self.mean_absolute_relative_error.shape)
-        return int(min_frame), int(min_filter)
+        extremum_index = np.nanargmin(self.summary) if extremum == "min" else np.nanargmax(self.summary)
+        frame_index, location_index = np.unravel_index(extremum_index, self.summary.shape)
+        return int(frame_index), int(location_index)
 
     @classmethod
     def load(cls, path: Path) -> Self:
@@ -193,26 +159,20 @@ class CorrugationResidualsData:
             verify_file_version_from_hdf5(file, cls.VERSION)
 
             name: str = get_str_attr_from_hdf5(file, "name")
+            metric_name: str = get_str_attr_from_hdf5(file, "metric_name")
 
             # Arrays
-            radii = verify_array_is_1d(read_dataset_from_hdf5_with_dtype(file, "radii", dtype=np.float32))
-            residuals = verify_array_is_3d(read_dataset_from_hdf5_with_dtype(file, "residuals", dtype=np.float32))
-            relative_errors = verify_array_is_3d(read_dataset_from_hdf5_with_dtype(file, "relative_errors", dtype=np.float32))
-            sum_of_square_residuals = verify_array_is_2d(
-                read_dataset_from_hdf5_with_dtype(file, "sum_of_square_residuals", dtype=np.float32)
-            )
-            mean_absolute_relative_error = verify_array_is_2d(
-                read_dataset_from_hdf5_with_dtype(file, "mean_absolute_relative_error", dtype=np.float32)
-            )
+            bin_values = verify_array_is_1d(read_dataset_from_hdf5_with_dtype(file, "bin_values", dtype=np.float32))
+            metric = verify_array_is_3d(read_dataset_from_hdf5_with_dtype(file, "metric", dtype=np.float32))
+            summary = verify_array_is_2d(read_dataset_from_hdf5_with_dtype(file, "summary", dtype=np.float32))
 
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, path.absolute())
         return cls(
-            residuals=residuals,
-            sum_of_square_residuals=sum_of_square_residuals,
-            relative_errors=relative_errors,
-            mean_absolute_relative_error=mean_absolute_relative_error,
-            radii=radii,
             name=name,
+            metric_name=metric_name,
+            metric=metric,
+            summary=summary,
+            bin_values=bin_values,
         )
 
     def dump(self, path: Path) -> None:
@@ -229,12 +189,10 @@ class CorrugationResidualsData:
             file.attrs["type"] = CorrugationResidualsData.DATA_FILE_TYPE
             file.attrs["version"] = str(CorrugationResidualsData.VERSION)
             file.attrs["name"] = self.name
-
-            file.create_dataset("residuals", data=self.residuals)
-            file.create_dataset("sum_of_square_residuals", data=self.sum_of_square_residuals)
-            file.create_dataset("relative_errors", data=self.relative_errors)
-            file.create_dataset("mean_absolute_relative_error", data=self.mean_absolute_relative_error)
-            file.create_dataset("radii", data=self.radii)
+            file.attrs["metric_name"] = self.metric_name
+            file.create_dataset("metric", data=self.metric)
+            file.create_dataset("summary", data=self.summary)
+            file.create_dataset("radii", data=self.bin_values)
         log.info(
             "Successfully dumped [cyan]%s[/cyan] to [magenta]%s[/magenta]", CorrugationResidualsData.__name__, path.absolute()
         )
@@ -243,12 +201,12 @@ class CorrugationResidualsData:
     @property
     def num_frames(self) -> int:
         """int: The number of frames."""
-        return self.residuals.shape[1]
+        return self.metric.shape[1]
 
     @property
-    def num_filters(self) -> int:
+    def num_locations(self) -> int:
         """int: The number of filters."""
-        return self.residuals.shape[2]
+        return self.metric.shape[2]
 
     def get_starting_angles_deg(self) -> _Array1D_f32:
         """Return the angle of the start locations in degrees.
@@ -259,4 +217,4 @@ class CorrugationResidualsData:
             The angle of the start locations in degrees.
 
         """
-        return np.linspace(0, 360, self.num_filters, endpoint=False)
+        return np.linspace(0, 360, self.num_locations, endpoint=False)

--- a/src/novie_data/signal_residuals_data.py
+++ b/src/novie_data/signal_residuals_data.py
@@ -1,0 +1,246 @@
+"""Data representing similarities between observed and simulated data."""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Literal, Self, TypeAlias
+
+import numpy as np
+from h5py import File as Hdf5File
+
+from novie_data._type_utils import Array1D, Array2D, Array3D, verify_array_is_1d, verify_array_is_2d, verify_array_is_3d
+from novie_data.errors import verify_arrays_are_consistent
+
+from .serde.accessors import get_str_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
+from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from packaging.version import Version
+
+_Array1D_f32: TypeAlias = Array1D[np.float32]
+_Array2D_f32: TypeAlias = Array2D[np.float32]
+_Array3D_f32: TypeAlias = Array3D[np.float32]
+
+log: logging.Logger = logging.getLogger(__name__)
+
+
+class SignalResidualsData(ABC):
+    """Data class to store residuals and errors from corrugation data processing.
+
+    Attributes
+    ----------
+    name : str
+        The name of the data set.
+    metric_name : str
+        The name of the metric used.
+    metric : Array3D[f32]
+        The value of the metric per point, frame and location.
+    summary : Array2D[f32]
+        The summary statistic of the metric per frame and location.
+    bin_values : Array1D[f32]
+        The central bin value for each bin.
+
+    """
+
+    @classmethod
+    @abstractmethod
+    def get_data_file_type(cls) -> str:
+        """Return the data file type string for this class.
+
+        Returns
+        -------
+        file_type : str
+            The data file type.
+
+        """
+        msg = "It is required to implement `get_data_file_type`!"
+        raise NotImplementedError(msg)
+
+    @classmethod
+    @abstractmethod
+    def get_version(cls) -> Version:
+        """Return the version for this class.
+
+        Returns
+        -------
+        version : Version
+            The file version.
+
+        """
+        msg = "It is required to implement `get_version`!"
+        raise NotImplementedError(msg)
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        metric_name: str,
+        metric: _Array3D_f32,
+        summary: _Array2D_f32,
+        bin_values: _Array1D_f32,
+    ) -> None:
+        """Initialize the data class.
+
+        Parameters
+        ----------
+        name : str
+            The name of the data set.
+        metric_name : str
+            The name of the metric used.
+        metric : Array3D[f32]
+            The value of the metric per point, frame and location.
+        summary : Array2D[f32]
+            The summary statistic of the metric per frame and location.
+        bin_values : Array1D[f32]
+            The central bin value for each bin.
+
+        """
+        self.name: str = name
+        self.metric_name: str = metric_name
+        self.metric: _Array3D_f32 = metric
+        self.summary: _Array2D_f32 = summary
+        self.bin_values: _Array1D_f32 = bin_values
+
+        verify_arrays_are_consistent(
+            [(self.bin_values, 0), (self.metric, 0)],
+            msg="Expected the bin values and metric arrays to have the same number of rows.",
+        )
+        verify_arrays_are_consistent(
+            [
+                (self.metric, 1),
+                (self.summary, 0),
+            ],
+            msg="Expected the arrays to have the same number of frames!",
+        )
+        verify_arrays_are_consistent(
+            [
+                (self.metric, 2),
+                (self.summary, 1),
+            ],
+            msg="Expected the arrays to have the same number of neighbourhoods!",
+        )
+
+    def __eq__(self, other: object, /) -> bool:
+        """Compare for equality.
+
+        Parameters
+        ----------
+        other : object
+            The object to compare to.
+
+        Returns
+        -------
+        bool
+            `True` if the other object is equal to this object, `False` otherwise.
+
+        Notes
+        -----
+        Equality means all fields are equal.
+
+        """
+        if not isinstance(other, type(self)):
+            return False
+        equality = True
+        equality &= self.name == other.name
+        equality &= self.metric_name == other.metric_name
+        equality &= np.all(self.bin_values == other.bin_values)
+        equality &= np.all(self.metric == other.metric)
+        equality &= np.all(self.summary == other.summary)
+        return bool(equality)
+
+    def get_extremal_index_over_summary(self, extremum: Literal["min", "max"]) -> tuple[int, int]:
+        """Get the frame and location indices that minimises the summary statistic.
+
+        Returns
+        -------
+        frame_index : int
+            The index of the frame that extremises the summary statistic.
+        location_index : int
+            The index of the location that extremises the summary statistic.
+
+        """
+        extremum_index = np.nanargmin(self.summary) if extremum == "min" else np.nanargmax(self.summary)
+        frame_index, location_index = np.unravel_index(extremum_index, self.summary.shape)
+        return int(frame_index), int(location_index)
+
+    @classmethod
+    def load(cls, path: Path) -> Self:
+        """Deserialize phase spiral data from file.
+
+        Parameters
+        ----------
+        path : Path
+            The path to the data.
+
+        Returns
+        -------
+        CorrugationResidualsData
+            The deserialized data.
+
+        """
+        with Hdf5File(path, "r") as file:
+            verify_file_type_from_hdf5(file, cls.get_data_file_type())
+            verify_file_version_from_hdf5(file, cls.get_version())
+
+            name: str = get_str_attr_from_hdf5(file, "name")
+            metric_name: str = get_str_attr_from_hdf5(file, "metric_name")
+
+            # Arrays
+            bin_values = verify_array_is_1d(read_dataset_from_hdf5_with_dtype(file, "bin_values", dtype=np.float32))
+            metric = verify_array_is_3d(read_dataset_from_hdf5_with_dtype(file, "metric", dtype=np.float32))
+            summary = verify_array_is_2d(read_dataset_from_hdf5_with_dtype(file, "summary", dtype=np.float32))
+
+        log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, path.absolute())
+        return cls(
+            name=name,
+            metric_name=metric_name,
+            metric=metric,
+            summary=summary,
+            bin_values=bin_values,
+        )
+
+    def dump(self, path: Path) -> None:
+        """Serialize data to disk.
+
+        Parameters
+        ----------
+        path : Path
+            The path to the data.
+
+        """
+        cls = type(self)
+        with Hdf5File(path, "w") as file:
+            # General
+            file.attrs["type"] = cls.get_data_file_type()
+            file.attrs["version"] = str(cls.get_version())
+            file.attrs["name"] = self.name
+            file.attrs["metric_name"] = self.metric_name
+            file.create_dataset("metric", data=self.metric)
+            file.create_dataset("summary", data=self.summary)
+            file.create_dataset("bin_values", data=self.bin_values)
+        log.info("Successfully dumped [cyan]%s[/cyan] to [magenta]%s[/magenta]", cls.__name__, path.absolute())
+
+    # Convenience functions
+    @property
+    def num_frames(self) -> int:
+        """int: The number of frames."""
+        return self.metric.shape[1]
+
+    @property
+    def num_locations(self) -> int:
+        """int: The number of filters."""
+        return self.metric.shape[2]
+
+    def get_starting_angles_deg(self) -> _Array1D_f32:
+        """Return the angle of the start locations in degrees.
+
+        Returns
+        -------
+        starting_angles : Array1D[f32]
+            The angle of the start locations in degrees.
+
+        """
+        return np.linspace(0, 360, self.num_locations, endpoint=False)

--- a/src/novie_data/wrinkle_residuals_data.py
+++ b/src/novie_data/wrinkle_residuals_data.py
@@ -1,16 +1,16 @@
-"""Data representing residuals and errors between observed and simulated wrinkle data."""
+"""Data representing residuals residuals and errors between observed and simulated wrinkle data."""
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, ClassVar, Self, TypeAlias
+from typing import TYPE_CHECKING, ClassVar, Literal, Self, TypeAlias
 
 import numpy as np
 from h5py import File as Hdf5File
 from packaging.version import Version
 
 from novie_data._type_utils import Array1D, Array2D, Array3D, verify_array_is_1d, verify_array_is_2d, verify_array_is_3d
-from novie_data.errors import verify_arrays_are_consistent, verify_arrays_have_same_shape
+from novie_data.errors import verify_arrays_are_consistent
 
 from .serde.accessors import get_str_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
 from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
@@ -18,12 +18,11 @@ from .serde.verification import verify_file_type_from_hdf5, verify_file_version_
 if TYPE_CHECKING:
     from pathlib import Path
 
-log: logging.Logger = logging.getLogger(__name__)
-
-
 _Array1D_f32: TypeAlias = Array1D[np.float32]
 _Array2D_f32: TypeAlias = Array2D[np.float32]
 _Array3D_f32: TypeAlias = Array3D[np.float32]
+
+log: logging.Logger = logging.getLogger(__name__)
 
 
 class WrinkleResidualsData:
@@ -33,31 +32,28 @@ class WrinkleResidualsData:
     ----------
     name : str
         The name of the data set.
-    angular_momentum : Array1D[f32]
-        The central angular momentum value for each bin in units of kpc km/s.
-    residuals : Array3D[f32]
-        The residuals between the test mean height and the expected mean height in units of kpc.
-    relative_errors : Array3D[f32]
-        The relative residuals between the test mean height and the expected mean height.
-    sum_of_square_residuals: Array2D[f32]
-        The sum of square residuals for each frame and filter in units of kpc**2.
-    mean_absolute_relative_error : Array2D[f32]
-        The mean absolute relative error.
+    metric_name : str
+        The name of the metric used.
+    metric : Array3D[f32]
+        The value of the metric per point, frame and location.
+    summary : Array2D[f32]
+        The summary statistic of the metric per frame and location.
+    bin_values : Array1D[f32]
+        The central bin value for each bin.
 
     """
 
-    DATA_FILE_TYPE: ClassVar[str] = "WrinkleResidualsData"
-    VERSION: ClassVar[Version] = Version("2.0.0")
+    DATA_FILE_TYPE: ClassVar[str] = "WrinkleResiduals"
+    VERSION: ClassVar[Version] = Version("3.0.0")
 
     def __init__(
         self,
         *,
         name: str,
-        angular_momentum: _Array1D_f32,
-        residuals: _Array3D_f32,
-        relative_errors: _Array3D_f32,
-        sum_of_square_residuals: _Array2D_f32,
-        mean_absolute_relative_error: _Array2D_f32,
+        metric_name: str,
+        metric: _Array3D_f32,
+        summary: _Array2D_f32,
+        bin_values: _Array1D_f32,
     ) -> None:
         """Initialize the data class.
 
@@ -65,52 +61,37 @@ class WrinkleResidualsData:
         ----------
         name : str
             The name of the data set.
-        angular_momentum : Array1D[f32]
-            The central angular momentum value for each bin in units of kpc km/s.
-        residuals : Array3D[f32]
-            The residuals between the test mean height and the expected mean height in units of kpc.
-        relative_errors : Array3D[f32]
-            The relative residuals between the test mean height and the expected mean height.
-        sum_of_square_residuals: Array2D[f32]
-            The sum of square residuals for each frame and filter in units of kpc**2.
-        mean_absolute_relative_error : Array2D[f32]
-            The mean absolute relative error.
+        metric_name : str
+            The name of the metric used.
+        metric : Array3D[f32]
+            The value of the metric per point, frame and location.
+        summary : Array2D[f32]
+            The summary statistic of the metric per frame and location.
+        bin_values : Array1D[f32]
+            The central bin value for each bin.
 
         """
         self.name: str = name
-        self.angular_momentum: _Array1D_f32 = angular_momentum
-        self.residuals: _Array3D_f32 = residuals
-        self.relative_errors: _Array3D_f32 = relative_errors
-        self.sum_of_square_residuals: _Array2D_f32 = sum_of_square_residuals
-        self.mean_absolute_relative_error: _Array2D_f32 = mean_absolute_relative_error
+        self.metric_name: str = metric_name
+        self.metric: _Array3D_f32 = metric
+        self.summary: _Array2D_f32 = summary
+        self.bin_values: _Array1D_f32 = bin_values
 
-        verify_arrays_have_same_shape(
-            [self.residuals, self.relative_errors],
-            msg="Expected the residuals and relative errors arrays to have the same shape!",
-        )
-        verify_arrays_have_same_shape(
-            [self.sum_of_square_residuals, self.mean_absolute_relative_error],
-            msg="Expected the SSE and MARE arrays to have the same shape!",
-        )
         verify_arrays_are_consistent(
-            [(self.angular_momentum, 0), (self.residuals, 0), (self.relative_errors, 0)],
-            msg="Expected the angular momentum, residuals and relative errors arrays to have the same number of rows.",
+            [(self.bin_values, 0), (self.metric, 0)],
+            msg="Expected the bin values and metric arrays to have the same number of rows.",
         )
         verify_arrays_are_consistent(
             [
-                (self.residuals, 1),
-                (self.relative_errors, 1),
-                (self.sum_of_square_residuals, 0),
-                (self.mean_absolute_relative_error, 0),
+                (self.metric, 1),
+                (self.summary, 0),
             ],
             msg="Expected the arrays to have the same number of frames!",
         )
         verify_arrays_are_consistent(
             [
-                (self.residuals, 2),
-                (self.relative_errors, 2),
-                (self.sum_of_square_residuals, 1),
-                (self.mean_absolute_relative_error, 1),
+                (self.metric, 2),
+                (self.summary, 1),
             ],
             msg="Expected the arrays to have the same number of neighbourhoods!",
         )
@@ -137,42 +118,26 @@ class WrinkleResidualsData:
             return False
         equality = True
         equality &= self.name == other.name
-        equality &= np.all(self.angular_momentum == other.angular_momentum)
-        equality &= np.all(self.residuals == other.residuals)
-        equality &= np.all(self.relative_errors == other.relative_errors)
-        equality &= np.all(self.sum_of_square_residuals == other.sum_of_square_residuals)
-        equality &= np.all(self.mean_absolute_relative_error == other.mean_absolute_relative_error)
+        equality &= self.metric_name == other.metric_name
+        equality &= np.all(self.bin_values == other.bin_values)
+        equality &= np.all(self.metric == other.metric)
+        equality &= np.all(self.summary == other.summary)
         return bool(equality)
 
-    def get_argmin_over_absolute(self) -> tuple[int, int]:
-        """Get the frame and filter indices that minimises the sum of square residuals.
+    def get_extremal_index_over_summary(self, extremum: Literal["min", "max"]) -> tuple[int, int]:
+        """Get the frame and location indices that minimises the summary statistic.
 
         Returns
         -------
-        min_frame : int
-            The index of the frame that minimises the sum of square residuals.
-        min_filter : int
-            The index of the filter that minimises the sum of square residuals.
+        frame_index : int
+            The index of the frame that extremises the summary statistic.
+        location_index : int
+            The index of the location that extremises the summary statistic.
 
         """
-        min_idx = np.nanargmin(self.sum_of_square_residuals)
-        min_frame, min_filter = np.unravel_index(min_idx, self.sum_of_square_residuals.shape)
-        return int(min_frame), int(min_filter)
-
-    def get_argmin_over_relative(self) -> tuple[int, int]:
-        """Get the frame and filter indices that minimises the mean absolute relative error.
-
-        Returns
-        -------
-        min_frame : int
-            The index of the frame that minimises the mean absolute relative error.
-        min_filter : int
-            The index of the filter that minimises the mean absolute relative error.
-
-        """
-        min_idx = np.nanargmin(self.mean_absolute_relative_error)
-        min_frame, min_filter = np.unravel_index(min_idx, self.mean_absolute_relative_error.shape)
-        return int(min_frame), int(min_filter)
+        extremum_index = np.nanargmin(self.summary) if extremum == "min" else np.nanargmax(self.summary)
+        frame_index, location_index = np.unravel_index(extremum_index, self.summary.shape)
+        return int(frame_index), int(location_index)
 
     @classmethod
     def load(cls, path: Path) -> Self:
@@ -194,25 +159,20 @@ class WrinkleResidualsData:
             verify_file_version_from_hdf5(file, cls.VERSION)
 
             name: str = get_str_attr_from_hdf5(file, "name")
+            metric_name: str = get_str_attr_from_hdf5(file, "metric_name")
 
             # Arrays
-            angular_momentum = verify_array_is_1d(read_dataset_from_hdf5_with_dtype(file, "radii", dtype=np.float32))
-            residuals = verify_array_is_3d(read_dataset_from_hdf5_with_dtype(file, "residuals", dtype=np.float32))
-            relative_errors = verify_array_is_3d(read_dataset_from_hdf5_with_dtype(file, "relative_errors", dtype=np.float32))
-            sum_of_square_residuals = verify_array_is_2d(
-                read_dataset_from_hdf5_with_dtype(file, "sum_of_square_residuals", dtype=np.float32)
-            )
-            mean_absolute_relative_error = verify_array_is_2d(
-                read_dataset_from_hdf5_with_dtype(file, "mean_absolute_relative_error", dtype=np.float32)
-            )
+            bin_values = verify_array_is_1d(read_dataset_from_hdf5_with_dtype(file, "bin_values", dtype=np.float32))
+            metric = verify_array_is_3d(read_dataset_from_hdf5_with_dtype(file, "metric", dtype=np.float32))
+            summary = verify_array_is_2d(read_dataset_from_hdf5_with_dtype(file, "summary", dtype=np.float32))
+
         log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, path.absolute())
         return cls(
-            residuals=residuals,
-            sum_of_square_residuals=sum_of_square_residuals,
-            relative_errors=relative_errors,
-            mean_absolute_relative_error=mean_absolute_relative_error,
-            angular_momentum=angular_momentum,
             name=name,
+            metric_name=metric_name,
+            metric=metric,
+            summary=summary,
+            bin_values=bin_values,
         )
 
     def dump(self, path: Path) -> None:
@@ -224,30 +184,27 @@ class WrinkleResidualsData:
             The path to the data.
 
         """
-        cls = type(self)
         with Hdf5File(path, "w") as file:
             # General
-            file.attrs["type"] = cls.DATA_FILE_TYPE
-            file.attrs["version"] = str(cls.VERSION)
+            file.attrs["type"] = WrinkleResidualsData.DATA_FILE_TYPE
+            file.attrs["version"] = str(WrinkleResidualsData.VERSION)
             file.attrs["name"] = self.name
-
-            file.create_dataset("residuals", data=self.residuals)
-            file.create_dataset("sum_of_square_residuals", data=self.sum_of_square_residuals)
-            file.create_dataset("relative_errors", data=self.relative_errors)
-            file.create_dataset("mean_absolute_relative_error", data=self.mean_absolute_relative_error)
-            file.create_dataset("radii", data=self.angular_momentum)
-        log.info("Successfully dumped [cyan]%s[/cyan] to [magenta]%s[/magenta]", cls.__name__, path.absolute())
+            file.attrs["metric_name"] = self.metric_name
+            file.create_dataset("metric", data=self.metric)
+            file.create_dataset("summary", data=self.summary)
+            file.create_dataset("radii", data=self.bin_values)
+        log.info("Successfully dumped [cyan]%s[/cyan] to [magenta]%s[/magenta]", WrinkleResidualsData.__name__, path.absolute())
 
     # Convenience functions
     @property
     def num_frames(self) -> int:
         """int: The number of frames."""
-        return self.residuals.shape[1]
+        return self.metric.shape[1]
 
     @property
-    def num_spheres(self) -> int:
-        """int: The number of spheres."""
-        return self.residuals.shape[2]
+    def num_locations(self) -> int:
+        """int: The number of filters."""
+        return self.metric.shape[2]
 
     def get_starting_angles_deg(self) -> _Array1D_f32:
         """Return the angle of the start locations in degrees.
@@ -258,4 +215,4 @@ class WrinkleResidualsData:
             The angle of the start locations in degrees.
 
         """
-        return np.linspace(0, 360, self.num_spheres, endpoint=False)
+        return np.linspace(0, 360, self.num_locations, endpoint=False)

--- a/src/novie_data/wrinkle_residuals_data.py
+++ b/src/novie_data/wrinkle_residuals_data.py
@@ -3,29 +3,16 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, ClassVar, Literal, Self, TypeAlias
+from typing import ClassVar
 
-import numpy as np
-from h5py import File as Hdf5File
 from packaging.version import Version
 
-from novie_data._type_utils import Array1D, Array2D, Array3D, verify_array_is_1d, verify_array_is_2d, verify_array_is_3d
-from novie_data.errors import verify_arrays_are_consistent
-
-from .serde.accessors import get_str_attr_from_hdf5, read_dataset_from_hdf5_with_dtype
-from .serde.verification import verify_file_type_from_hdf5, verify_file_version_from_hdf5
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-_Array1D_f32: TypeAlias = Array1D[np.float32]
-_Array2D_f32: TypeAlias = Array2D[np.float32]
-_Array3D_f32: TypeAlias = Array3D[np.float32]
+from .signal_residuals_data import SignalResidualsData
 
 log: logging.Logger = logging.getLogger(__name__)
 
 
-class WrinkleResidualsData:
+class WrinkleResidualsData(SignalResidualsData):
     """Data class to store residuals and errors from wrinkle data processing.
 
     Attributes
@@ -46,173 +33,26 @@ class WrinkleResidualsData:
     DATA_FILE_TYPE: ClassVar[str] = "WrinkleResiduals"
     VERSION: ClassVar[Version] = Version("3.0.0")
 
-    def __init__(
-        self,
-        *,
-        name: str,
-        metric_name: str,
-        metric: _Array3D_f32,
-        summary: _Array2D_f32,
-        bin_values: _Array1D_f32,
-    ) -> None:
-        """Initialize the data class.
-
-        Parameters
-        ----------
-        name : str
-            The name of the data set.
-        metric_name : str
-            The name of the metric used.
-        metric : Array3D[f32]
-            The value of the metric per point, frame and location.
-        summary : Array2D[f32]
-            The summary statistic of the metric per frame and location.
-        bin_values : Array1D[f32]
-            The central bin value for each bin.
-
-        """
-        self.name: str = name
-        self.metric_name: str = metric_name
-        self.metric: _Array3D_f32 = metric
-        self.summary: _Array2D_f32 = summary
-        self.bin_values: _Array1D_f32 = bin_values
-
-        verify_arrays_are_consistent(
-            [(self.bin_values, 0), (self.metric, 0)],
-            msg="Expected the bin values and metric arrays to have the same number of rows.",
-        )
-        verify_arrays_are_consistent(
-            [
-                (self.metric, 1),
-                (self.summary, 0),
-            ],
-            msg="Expected the arrays to have the same number of frames!",
-        )
-        verify_arrays_are_consistent(
-            [
-                (self.metric, 2),
-                (self.summary, 1),
-            ],
-            msg="Expected the arrays to have the same number of neighbourhoods!",
-        )
-
-    def __eq__(self, other: object, /) -> bool:
-        """Compare for equality.
-
-        Parameters
-        ----------
-        other : object
-            The object to compare to.
+    @classmethod
+    def get_data_file_type(cls) -> str:
+        """Return the data file type string for this class.
 
         Returns
         -------
-        bool
-            `True` if the other object is equal to this object, `False` otherwise.
-
-        Notes
-        -----
-        Equality means all fields are equal.
+        file_type : str
+            The data file type.
 
         """
-        if not isinstance(other, type(self)):
-            return False
-        equality = True
-        equality &= self.name == other.name
-        equality &= self.metric_name == other.metric_name
-        equality &= np.all(self.bin_values == other.bin_values)
-        equality &= np.all(self.metric == other.metric)
-        equality &= np.all(self.summary == other.summary)
-        return bool(equality)
-
-    def get_extremal_index_over_summary(self, extremum: Literal["min", "max"]) -> tuple[int, int]:
-        """Get the frame and location indices that minimises the summary statistic.
-
-        Returns
-        -------
-        frame_index : int
-            The index of the frame that extremises the summary statistic.
-        location_index : int
-            The index of the location that extremises the summary statistic.
-
-        """
-        extremum_index = np.nanargmin(self.summary) if extremum == "min" else np.nanargmax(self.summary)
-        frame_index, location_index = np.unravel_index(extremum_index, self.summary.shape)
-        return int(frame_index), int(location_index)
+        return cls.DATA_FILE_TYPE
 
     @classmethod
-    def load(cls, path: Path) -> Self:
-        """Deserialize phase spiral data from file.
-
-        Parameters
-        ----------
-        path : Path
-            The path to the data.
+    def get_version(cls) -> Version:
+        """Return the version for this class.
 
         Returns
         -------
-        WrinkleResidualsData
-            The deserialized data.
+        version : Version
+            The file version.
 
         """
-        with Hdf5File(path, "r") as file:
-            verify_file_type_from_hdf5(file, cls.DATA_FILE_TYPE)
-            verify_file_version_from_hdf5(file, cls.VERSION)
-
-            name: str = get_str_attr_from_hdf5(file, "name")
-            metric_name: str = get_str_attr_from_hdf5(file, "metric_name")
-
-            # Arrays
-            bin_values = verify_array_is_1d(read_dataset_from_hdf5_with_dtype(file, "bin_values", dtype=np.float32))
-            metric = verify_array_is_3d(read_dataset_from_hdf5_with_dtype(file, "metric", dtype=np.float32))
-            summary = verify_array_is_2d(read_dataset_from_hdf5_with_dtype(file, "summary", dtype=np.float32))
-
-        log.info("Successfully loaded [cyan]%s[/cyan] from [magenta]%s[/magenta]", cls.__name__, path.absolute())
-        return cls(
-            name=name,
-            metric_name=metric_name,
-            metric=metric,
-            summary=summary,
-            bin_values=bin_values,
-        )
-
-    def dump(self, path: Path) -> None:
-        """Serialize phase spiral data to disk.
-
-        Parameters
-        ----------
-        path : Path
-            The path to the data.
-
-        """
-        with Hdf5File(path, "w") as file:
-            # General
-            file.attrs["type"] = WrinkleResidualsData.DATA_FILE_TYPE
-            file.attrs["version"] = str(WrinkleResidualsData.VERSION)
-            file.attrs["name"] = self.name
-            file.attrs["metric_name"] = self.metric_name
-            file.create_dataset("metric", data=self.metric)
-            file.create_dataset("summary", data=self.summary)
-            file.create_dataset("radii", data=self.bin_values)
-        log.info("Successfully dumped [cyan]%s[/cyan] to [magenta]%s[/magenta]", WrinkleResidualsData.__name__, path.absolute())
-
-    # Convenience functions
-    @property
-    def num_frames(self) -> int:
-        """int: The number of frames."""
-        return self.metric.shape[1]
-
-    @property
-    def num_locations(self) -> int:
-        """int: The number of filters."""
-        return self.metric.shape[2]
-
-    def get_starting_angles_deg(self) -> _Array1D_f32:
-        """Return the angle of the start locations in degrees.
-
-        Returns
-        -------
-        starting_angles : Array1D[f32]
-            The angle of the start locations in degrees.
-
-        """
-        return np.linspace(0, 360, self.num_locations, endpoint=False)
+        return cls.VERSION

--- a/tests/test_corrugation_residuals_data.py
+++ b/tests/test_corrugation_residuals_data.py
@@ -23,11 +23,10 @@ def test_corrugation_residuals_data_init() -> None:
     sse = np.zeros((num_frames, num_neighbourhoods), dtype=np.float32)
     s = CorrugationResidualsData(
         name="test",
-        radii=radii,
-        residuals=residuals,
-        relative_errors=residuals,
-        sum_of_square_residuals=sse,
-        mean_absolute_relative_error=sse,
+        metric_name="sse",
+        metric=residuals,
+        summary=sse,
+        bin_values=radii,
     )
     assert s.name == "test"
 
@@ -50,11 +49,10 @@ def test_corrugation_residuals_data_serde(tmp_path: Path) -> None:
     sse = np.zeros((num_frames, num_neighbourhoods), dtype=np.float32)
     s = CorrugationResidualsData(
         name="test",
-        radii=radii,
-        residuals=residuals,
-        relative_errors=residuals,
-        sum_of_square_residuals=sse,
-        mean_absolute_relative_error=sse,
+        metric_name="sse",
+        metric=residuals,
+        summary=sse,
+        bin_values=radii,
     )
     s.dump(output_path)
     t = CorrugationResidualsData.load(output_path)

--- a/tests/test_wrinkle_residuals_data.py
+++ b/tests/test_wrinkle_residuals_data.py
@@ -23,11 +23,10 @@ def test_wrinkle_residuals_data_init() -> None:
     sse = np.zeros((num_frames, num_neighbourhoods), dtype=np.float32)
     s = WrinkleResidualsData(
         name="test",
-        angular_momentum=angular_momentum,
-        residuals=residuals,
-        relative_errors=residuals,
-        sum_of_square_residuals=sse,
-        mean_absolute_relative_error=sse,
+        metric_name="sse",
+        metric=residuals,
+        summary=sse,
+        bin_values=angular_momentum,
     )
     assert s.name == "test"
 
@@ -50,11 +49,10 @@ def test_wrinkle_residuals_data_serde(tmp_path: Path) -> None:
     sse = np.zeros((num_frames, num_neighbourhoods), dtype=np.float32)
     s = WrinkleResidualsData(
         name="test",
-        angular_momentum=angular_momentum,
-        residuals=residuals,
-        relative_errors=residuals,
-        sum_of_square_residuals=sse,
-        mean_absolute_relative_error=sse,
+        metric_name="sse",
+        metric=residuals,
+        summary=sse,
+        bin_values=angular_momentum,
     )
     s.dump(output_path)
     t = WrinkleResidualsData.load(output_path)


### PR DESCRIPTION
Instead of replicating the interface between corrugation and wrinkle residuals data, as the data is basically the same between the two, I implemented a base class implementation with the subclasses only needing to define their file type string and their version.